### PR TITLE
Added data field to traversals in dsl specification

### DIFF
--- a/cocogen/frontend/ast/ast.h
+++ b/cocogen/frontend/ast/ast.h
@@ -71,10 +71,7 @@ enum ActionType {
     ACTION_REFERENCE
 };
 
-enum LifetimeType {
-    LIFETIME_DISALLOWED,
-    LIFETIME_MANDATORY
-};
+enum LifetimeType { LIFETIME_DISALLOWED, LIFETIME_MANDATORY };
 
 typedef struct ccn_sub_root_pair {
     char *from;
@@ -88,7 +85,8 @@ typedef struct Range_spec {
     array *ids; // Ids of the action this spec starts or end, with namespacing.
     unsigned int id_index;
     bool inclusive; // Range inclusive over the action or not.
-    char *consistency_key; // Key used to lookup this spec in the consistency map.
+    char *
+        consistency_key; // Key used to lookup this spec in the consistency map.
     char *type;
     bool push; // Either push this spec or pop.
     enum LifetimeType life_type;
@@ -105,7 +103,6 @@ struct Lifetime {
     bool owner;
     char *original_value;
     array *values;
-
 };
 
 typedef struct Config {
@@ -124,7 +121,6 @@ typedef struct Config {
 
     struct NodeCommonInfo *common_info;
 } Config;
-
 
 struct Phase {
     char *id;
@@ -165,13 +161,16 @@ typedef struct Traversal {
         SetExpr *expr;
     };
 
+    array *data;
+
     struct NodeCommonInfo *common_info;
 } Traversal;
 
 typedef struct Action {
     enum ActionType type;
     uint32_t id_counter;
-    bool action_owner; // We create shallow actions, that do not own the actual action.
+    bool action_owner; // We create shallow actions, that do not own the actual
+                       // action.
     bool checked;
     void *action;
     char *id;

--- a/cocogen/frontend/ast/ast.h
+++ b/cocogen/frontend/ast/ast.h
@@ -279,6 +279,24 @@ typedef struct AttrValue {
     struct NodeCommonInfo *common_info;
 } AttrValue;
 
+typedef struct TravDataConstructor {
+    char *constructor;
+    array *arglist;
+    char *include;
+} TravDataConstructor;
+
+typedef struct TravData {
+    enum AttrType type;
+    char *type_id;
+    char *id;
+    union {
+        AttrValue *primitive_value;
+        TravDataConstructor *constructor;
+    } value;
+
+    struct NodeCommonInfo *common_info;
+} TravData;
+
 /**
  * @struct SetOperation
  * @brief The structure to store a set operation on two expressions.

--- a/cocogen/frontend/ast/check.c
+++ b/cocogen/frontend/ast/check.c
@@ -680,6 +680,45 @@ static int check_traversal(Traversal *traversal, struct Info *info) {
         }
     }
 
+    smap_t *attr_name = smap_init(16);
+
+    if (traversal->data) {
+        for (int i = 0; i < array_size(traversal->data); i++) {
+            Attr *attr = (Attr *)array_get(traversal->data, i);
+            Attr *orig_attr;
+
+            if ((orig_attr = smap_retrieve(attr_name, attr->id)) != NULL) {
+                print_error(
+                    attr->id,
+                    "Duplicate name '%s' in atributes of traversal '%s'",
+                    attr->id, traversal->id);
+                print_note(orig_attr->id, "Previously declared here");
+                error = 1;
+            } else {
+                smap_insert(attr_name, attr->id, attr);
+            }
+
+            if (attr->type == AT_link_or_enum) {
+                Node *attr_node =
+                    (Node *)smap_retrieve(info->node_name, attr->type_id);
+                Enum *attr_enum =
+                    (Enum *)smap_retrieve(info->enum_name, attr->type_id);
+
+                if (attr_node) {
+                    attr->type = AT_link;
+                } else if (attr_enum) {
+                    attr->type = AT_enum;
+                } else {
+                    print_error(
+                        attr->type_id,
+                        "Unknown type '%s' of attribute '%s' of traversal '%s'",
+                        attr->type_id, attr->id, traversal->id);
+                    error = 1;
+                }
+            }
+        }
+    }
+
     /// TODO: Something with cleaning the array? probably happens somewhere else
     // array_cleanup(traversal->nodes, NULL);
     // traversal->nodes = nodes_expanded;

--- a/cocogen/frontend/ast/check.c
+++ b/cocogen/frontend/ast/check.c
@@ -680,39 +680,39 @@ static int check_traversal(Traversal *traversal, struct Info *info) {
         }
     }
 
-    smap_t *attr_name = smap_init(16);
+    smap_t *td_name = smap_init(16);
 
     if (traversal->data) {
         for (int i = 0; i < array_size(traversal->data); i++) {
-            Attr *attr = (Attr *)array_get(traversal->data, i);
-            Attr *orig_attr;
+            TravData *td = (TravData *)array_get(traversal->data, i);
+            TravData *orig_td;
 
-            if ((orig_attr = smap_retrieve(attr_name, attr->id)) != NULL) {
+            if ((orig_td = smap_retrieve(td_name, td->id)) != NULL) {
                 print_error(
-                    attr->id,
+                    td->id,
                     "Duplicate name '%s' in atributes of traversal '%s'",
-                    attr->id, traversal->id);
-                print_note(orig_attr->id, "Previously declared here");
+                    td->id, traversal->id);
+                print_note(orig_td->id, "Previously declared here");
                 error = 1;
             } else {
-                smap_insert(attr_name, attr->id, attr);
+                smap_insert(td_name, td->id, td);
             }
 
-            if (attr->type == AT_link_or_enum) {
+            if (td->type == AT_link_or_enum) {
                 Node *attr_node =
-                    (Node *)smap_retrieve(info->node_name, attr->type_id);
+                    (Node *)smap_retrieve(info->node_name, td->type_id);
                 Enum *attr_enum =
-                    (Enum *)smap_retrieve(info->enum_name, attr->type_id);
+                    (Enum *)smap_retrieve(info->enum_name, td->type_id);
 
                 if (attr_node) {
-                    attr->type = AT_link;
+                    td->type = AT_link;
                 } else if (attr_enum) {
-                    attr->type = AT_enum;
+                    td->type = AT_enum;
                 } else {
                     print_error(
-                        attr->type_id,
+                        td->type_id,
                         "Unknown type '%s' of attribute '%s' of traversal '%s'",
-                        attr->type_id, attr->id, traversal->id);
+                        td->type_id, td->id, traversal->id);
                     error = 1;
                 }
             }

--- a/cocogen/frontend/ast/check.c
+++ b/cocogen/frontend/ast/check.c
@@ -697,25 +697,6 @@ static int check_traversal(Traversal *traversal, struct Info *info) {
             } else {
                 smap_insert(td_name, td->id, td);
             }
-
-            if (td->type == AT_link_or_enum) {
-                Node *attr_node =
-                    (Node *)smap_retrieve(info->node_name, td->type_id);
-                Enum *attr_enum =
-                    (Enum *)smap_retrieve(info->enum_name, td->type_id);
-
-                if (attr_node) {
-                    td->type = AT_link;
-                } else if (attr_enum) {
-                    td->type = AT_enum;
-                } else {
-                    print_error(
-                        td->type_id,
-                        "Unknown type '%s' of attribute '%s' of traversal '%s'",
-                        td->type_id, td->id, traversal->id);
-                    error = 1;
-                }
-            }
         }
     }
 

--- a/cocogen/frontend/ast/create.c
+++ b/cocogen/frontend/ast/create.c
@@ -275,6 +275,37 @@ Action *create_action(enum ActionType type, void *action, char *id) {
     return _action;
 }
 
+TravData *create_travdata_primitive(enum AttrType type, char *id,
+                                    AttrValue *value) {
+
+    TravData *td = mem_alloc(sizeof(TravData));
+    td->type = type;
+    td->type_id = NULL;
+    td->id = id;
+    td->value.primitive_value = value;
+
+    td->common_info = create_commoninfo();
+    return td;
+}
+
+TravData *create_travdata_struct(char *type, char *id, char *constructor,
+                                 array *arglist, char *include) {
+
+    TravData *td = mem_alloc(sizeof(TravData));
+    td->type = AT_link_or_enum;
+    td->type_id = type;
+    td->id = id;
+
+    TravDataConstructor *tdc = mem_alloc(sizeof(TravDataConstructor));
+    tdc->arglist = arglist;
+    tdc->constructor = constructor;
+    tdc->include = include;
+    td->value.constructor = tdc;
+
+    td->common_info = create_commoninfo();
+    return td;
+}
+
 Attr *create_attr(Attr *a, AttrValue *default_value, int construct,
                   array *lifetimes) {
     a->default_value = default_value;

--- a/cocogen/frontend/ast/create.c
+++ b/cocogen/frontend/ast/create.c
@@ -54,7 +54,8 @@ Phase *create_phase_header(char *id, bool start, bool cycle) {
     return p;
 }
 
-Phase *create_phase(Phase *phase_header, char *root, char *prefix, array *actions, char *gate_func) {
+Phase *create_phase(Phase *phase_header, char *root, char *prefix,
+                    array *actions, char *gate_func) {
 
     Phase *p = phase_header;
     p->root = root;
@@ -78,7 +79,8 @@ Pass *create_pass(char *id, char *func, char *prefix) {
     return p;
 }
 
-Traversal *create_traversal(char *id, char *func, char *prefix, SetExpr *expr) {
+Traversal *create_traversal(char *id, char *func, char *prefix, SetExpr *expr,
+                            array *data) {
 
     Traversal *t = mem_alloc(sizeof(Traversal));
     t->id = id;
@@ -86,6 +88,7 @@ Traversal *create_traversal(char *id, char *func, char *prefix, SetExpr *expr) {
     t->info = NULL;
     t->prefix = prefix;
     t->expr = expr;
+    t->data = data;
 
     t->common_info = create_commoninfo();
     return t;
@@ -219,10 +222,7 @@ Lifetime_t *create_lifetime(Range_spec_t *start, Range_spec_t *end,
     return lifetime;
 }
 
-
-
-Child *create_child(int construct, array *lifetimes,
-                    char *id, char *type) {
+Child *create_child(int construct, array *lifetimes, char *id, char *type) {
 
     Child *c = mem_alloc(sizeof(Child));
     c->construct = construct;
@@ -275,7 +275,8 @@ Action *create_action(enum ActionType type, void *action, char *id) {
     return _action;
 }
 
-Attr *create_attr(Attr *a, AttrValue *default_value, int construct, array *lifetimes) {
+Attr *create_attr(Attr *a, AttrValue *default_value, int construct,
+                  array *lifetimes) {
     a->default_value = default_value;
     a->construct = construct;
     a->lifetimes = lifetimes;

--- a/cocogen/frontend/ast/create.h
+++ b/cocogen/frontend/ast/create.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include "lib/array.h"
 #include <stdbool.h>
 #include <stdint.h>
@@ -10,11 +9,13 @@ Config *create_config(array *phases, array *passes, array *traversals,
 
 Pass *create_pass(char *id, char *func, char *prefix);
 
-Traversal *create_traversal(char *id, char *func, char *prefix, SetExpr *expr);
+Traversal *create_traversal(char *id, char *func, char *prefix, SetExpr *expr,
+                            array *data);
 
 Phase *create_phase_header(char *id, bool root, bool cycle);
 
-Phase *create_phase(Phase *phase_header, char *root, char *prefix, array *actions, char *gate);
+Phase *create_phase(Phase *phase_header, char *root, char *prefix,
+                    array *actions, char *gate);
 
 Enum *create_enum(char *id, char *prefix, array *values);
 
@@ -29,8 +30,7 @@ Node *create_node(char *id, Node *nodebody);
 
 Node *create_nodebody(array *children, array *attrs);
 
-Child *create_child(int construct, array *lifetimes,
-                    char *id, char *type);
+Child *create_child(int construct, array *lifetimes, char *id, char *type);
 
 MandatoryPhase *create_mandatory_singlephase(char *phase, int negation);
 
@@ -43,7 +43,8 @@ Range_spec_t *create_range_spec(bool inclusive, array *);
 Lifetime_t *create_lifetime(Range_spec_t *start, Range_spec_t *end,
                             enum LifetimeType type, array *values);
 
-Attr *create_attr(Attr *attrhead, AttrValue *default_value, int construct, array *lifetimes);
+Attr *create_attr(Attr *attrhead, AttrValue *default_value, int construct,
+                  array *lifetimes);
 
 Attr *create_attrhead_primitive(enum AttrType type, char *id);
 

--- a/cocogen/frontend/ast/create.h
+++ b/cocogen/frontend/ast/create.h
@@ -63,3 +63,9 @@ AttrValue *create_attrval_float(float value);
 AttrValue *create_attrval_double(double value);
 
 AttrValue *create_attrval_id(char *id);
+
+TravData *create_travdata_primitive(enum AttrType type, char *id,
+                                    AttrValue *value);
+
+TravData *create_travdata_struct(char *type, char *id, char *constructor,
+                                 array *arglist, char *include);

--- a/cocogen/frontend/scanparse/dsl-lexer.l
+++ b/cocogen/frontend/scanparse/dsl-lexer.l
@@ -147,6 +147,7 @@ static inline void check_c_keyword(const char *);
 "false"         { LEX_KEYWORD(T_FALSE);}
 "true"          { LEX_KEYWORD(T_TRUE);}
 "gate"          { LEX_KEYWORD(T_GATE);}
+"unsafe"        { LEX_KEYWORD(T_UNSAFE);}
 
 "NULL"          { return T_NULL;}
 

--- a/cocogen/frontend/scanparse/dsl-lexer.l
+++ b/cocogen/frontend/scanparse/dsl-lexer.l
@@ -121,6 +121,7 @@ static inline void check_c_keyword(const char *);
 "subphases"     { LEX_KEYWORD(T_SUBPHASES);}
 "to"            { LEX_KEYWORD(T_TO);}
 "traversal"     { LEX_KEYWORD(T_TRAVERSAL);}
+"travdata"      { LEX_KEYWORD(T_TRAVDATA);}
 "values"        { LEX_KEYWORD(T_VALUES) ; }
 "info"          { LEX_KEYWORD(T_INFO) ; }
 "func"          { LEX_KEYWORD(T_FUNC) ; }

--- a/cocogen/frontend/scanparse/dsl-parser.y
+++ b/cocogen/frontend/scanparse/dsl-parser.y
@@ -145,6 +145,7 @@ static void new_location(void *ptr, struct ParserLocation *loc);
 %token T_DISALLOWED "disallowed"
 %token T_GATE "gate"
 %token T_ARROW "->"
+%token T_UNSAFE "unsafe"
 %token END 0 "End-of-file (EOF)"
 
 %type<string> info func prefix
@@ -961,13 +962,13 @@ travdatalist: travdatalist ',' travdataitem
         }
         ;
 
-travdataitem: T_ID T_ID '=' T_ID '(' attrvallist ')' '{' T_STRINGVAL '}'
+travdataitem: T_UNSAFE T_ID T_ID '=' T_ID '(' attrvallist ')' '{' T_STRINGVAL '}'
     {
-        $$ = create_travdata_struct($1, $2, $4, $6, $9);
+        $$ = create_travdata_struct($2, $3, $5, $7, $10);
         new_location($$, &@$);
-        new_location($2, &@2);
-        new_location($4, &@4);
-        new_location($9, &@9);
+        new_location($3, &@2);
+        new_location($5, &@4);
+        new_location($10, &@9);
     }
     | attrprimitivetype T_ID '=' attrval
     {

--- a/example/civic.coconut
+++ b/example/civic.coconut
@@ -70,7 +70,7 @@ traversal Print {
     prefix = PRT,
     travdata = {
         int test2 = 0,
-        smap_t testmap = smap_init(10) { "lib/smap.h" }
+        unsafe smap_t testmap = smap_init(10) { "lib/smap.h" }
     }
 };
 

--- a/example/civic.coconut
+++ b/example/civic.coconut
@@ -69,8 +69,8 @@ pass Test;
 traversal Print {
     prefix = PRT,
     travdata = {
-        int test1 = 0,
-        int test2 = 0
+        int test2 = 0,
+        smap_t testmap = smap_init(10) { "lib/smap.h" }
     }
 };
 

--- a/example/civic.coconut
+++ b/example/civic.coconut
@@ -66,7 +66,14 @@ enum BinOpEnum {
 
 pass Test;
 
-traversal Print;
+traversal Print {
+    prefix = PRT,
+    travdata = {
+        int test1 = 0,
+        int test2 = 0
+    }
+};
+
 traversal ByteCode = {BinOp, FunDef};
 
 traversal RenameFor {


### PR DESCRIPTION
Added a field in the dsl specification in which the user can specify their own data used in the traversal. This is done by reusing the 'Attr' type. It is unsure if this is the best way of using this.